### PR TITLE
fix css reloading

### DIFF
--- a/lib/finders/ComponentFinder.js
+++ b/lib/finders/ComponentFinder.js
@@ -212,7 +212,7 @@ class ComponentFinder extends EventEmitter {
           }
         });
 
-        if (relativeAssets.includes(filename)) {
+        if (relativeAssets.indexOf(filename) > -1) {
           this.emit('changeLogic', component);
           this.emit('change', changeArgs);
           return;


### PR DESCRIPTION
CSS-files don't reload after changes (component views the same classes as before changing css)
Problem is `Array.prototype.includes()`
Thanks to @morhetz for bug resolving